### PR TITLE
Update dependencies on v10 branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in shop_invader.gemspec
 gemspec
 
-gem 'locomotivecms_steam', github: 'akretion/steam', branch: 'pending-pr'
+gem 'locomotivecms_steam', github: 'locomotivecms/steam'
 gem 'faraday'
 
 gem 'simplecov', require: false, group: :test

--- a/shop_invader.gemspec
+++ b/shop_invader.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'algoliasearch', '~> 1.13.0'
-  spec.add_dependency 'faraday', '~> 0.11.0'
+  spec.add_dependency 'faraday', '~> 0.14.0'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/shop_invader.gemspec
+++ b/shop_invader.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'algoliasearch', '~> 1.13.0'
+  spec.add_dependency 'algoliasearch', '~> 1.21.0'
   spec.add_dependency 'faraday', '~> 0.14.0'
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
as far as I can see, all patches from https://github.com/akretion/steam/commits/pending-pr are merged into https://github.com/locomotivecms/steam so I believe we can use the official branch again.

Upgrading faraday to 0.14.0 is required to avoid conflicts with newer locomotivecms/coal.

Upgrading is also required to have Ruby 2.5 compatibility, which is important for wagon as Ruby 2.5 is the default Ruby on Ubuntu Bionic.

Upgrading algosearch is more optional, but if tests pass, I propose not procrastinating it.